### PR TITLE
fix(readme): correct the vitepress name spelling

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ All **suggestions/PR** are welcome!
 | Vue | <https://vuejs.org> |
 | Vue Router | <https://router.vuejs.org> |
 | Pinia | <https://pinia.vuejs.org> |
-| Vitepre | <https://vitepress.dev> |
+| VitePress | <https://vitepress.dev> |
 | Python Cheatsheet | <https://www.pythoncheatsheet.org> |
 
 ## Copyright and license ©


### PR DESCRIPTION
In this pull request, as its own name suggest, I am just correcting the name spelling of the VitePress that was written as **Vitepre** to **VitePress**.